### PR TITLE
Support Comments in .addon files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		],
 		"languages": [
 			{
-				"id": "json",
+				"id": "jsonc",
 				"aliases": [
 					"S&box Addon"
 				],


### PR DESCRIPTION
Currently, .addon files are marked as json, which disallows comments. Changing the language to "Json with Comments" (jsonc) prevents all comments being marked as errors.


Json Language:
![json](https://user-images.githubusercontent.com/35181365/124359841-990fa100-dc1e-11eb-9560-7046c479334b.png)

Jsonc Language:
![jsonc](https://user-images.githubusercontent.com/35181365/124359872-b80e3300-dc1e-11eb-87a9-b52cccaf44a7.png)
